### PR TITLE
fix .iteritems() replace by .items() in python3

### DIFF
--- a/pysproto/sprotodump.py
+++ b/pysproto/sprotodump.py
@@ -182,7 +182,7 @@ def packgroup(t, p) -> bytes:
     tt = packbytes(tt.getvalue())
     if p:
         tmp = []
-        for name, tbl in p.iteritems():
+        for name, tbl in p.items():
             tmp.append(tbl)
             tbl["name"] = name
         tmp = sorted(tmp, key=lambda k: k["tag"])

--- a/pysproto/sprotoparser.py
+++ b/pysproto/sprotoparser.py
@@ -231,14 +231,14 @@ def parse_list(sproto_list):
         ast = Convert.parse(v[0], v[1])
 
         # merge type
-        for stname, stype in ast["type"].iteritems():
+        for stname, stype in ast["type"].items():
             assert stname not in build["type"], "redifine type %s in %s" % (
                 stname,
                 v[1],
             )
             build["type"][stname] = stype
         # merge protocol
-        for spname, sp in ast["protocol"].iteritems():
+        for spname, sp in ast["protocol"].items():
             assert (
                 spname not in build["protocol"]
             ), "redifine protocol name %s in %s" % (spname, v[1])


### PR DESCRIPTION
# python版本
```
$ python -V
Python 3.11.2
```

# 报错
```
  File "/home/amao/github/sproto/pysproto/sprotoparser.py", line 234, in parse_list
    for stname, stype in ast["type"].iteritems():
                         ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'iteritems
```

# 示例
使用[sprotoparser.parse_list(sproto_list)](https://github.com/synodriver/sproto/blob/main/pysproto/sprotoparser.py#L228)批量处理sproto文件，样例代码为下：
```python
import os
import pysproto.sprotoparser as sprotoparser
from pysproto import parse, parse_ast, Sproto

# 该目录下存放了.sproto文件
src_dir = "./proto"

# 参考sprotodump --directory选项的代码，读取所有.sproto文件内容
sproto_list = []
for f in os.listdir(src_dir):
    file_path = os.path.join(src_dir, f)
    if os.path.isfile(file_path) and f.endswith(".sproto"):
        text = open(file_path, encoding="utf-8").read()
        sproto_list.append((text, f))

# sprotoparser.parse_list批量解析
build = sprotoparser.parse_list(sproto_list)
dump = parse_ast(build)
proto = Sproto(dump)
tp = proto.querytype("Person")
encoded = tp.encode({"name": "my_name"})
print(tp.decode(encoded))
```
以上样例目录proto下的文件
```
./proto/
└── person.sproto
```
```
// file: Person.sproto

.Person {
    name 0 : string
    id 1 : integer
    email 2 : string
    real 3: double
}
```

# Pull requests
python3里iteritems已经被移除，用items替代

## Summary by Sourcery

Bug Fixes:
- Replace deprecated .iteritems() with .items() in Python 3 code to fix AttributeError.